### PR TITLE
v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v2.0.0
+# v2.0.0 (Nov 8, 2019)
 
  * BREAKING CHANGE: Renamed 'sdk' and 'ndk' to 'sdks' and 'ndks'.
  * BREAKING CHANGE: No longer scan for deprecated 'android' executable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v2.0.0
+
+ * BREAKING CHANGE: Renamed 'sdk' and 'ndk' to 'sdks' and 'ndks'.
+ * BREAKING CHANGE: No longer scan for deprecated 'android' executable.
+ * BREAKING CHANGE: Removed 'targets'. Combine 'addons' and 'platforms' to get same result.
+ * fix: Fixed bug with selecting the correct default Android SDK.
+ * feat: Wired up live configuration changes.
+   [(DAEMON-198)](https://jira.appcelerator.org/browse/DAEMON-198)
+ * chore: Update dependencies.
+
 # v1.5.0 (Aug 14, 2019)
 
  * chore: Added Appc Daemon v3 to list of compatible appcd versions.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Android service for the Appc Daemon.
 
+Report issues to [GitHub issues][2]. Official issue tracker in [JIRA][3].
+
 ## Info
 
 The `info` service uses [androidlib](https://github.com/appcelerator/androidlib) to detect the
@@ -19,3 +21,5 @@ This project is open source under the [Apache Public License v2][1] and is devel
 in this distribution for more information.
 
 [1]: https://github.com/appcelerator/appcd-plugin-android/blob/master/LICENSE
+[2]: https://github.com/appcelerator/appcd-plugin-android/issues
+[3]: https://jira.appcelerator.org/projects/DAEMON/issues

--- a/conf/config.js
+++ b/conf/config.js
@@ -9,7 +9,7 @@ module.exports = {
 		},
 
 		/**
-		 * The port number ADB is listening.
+		 * The port to connect to ADB.
 		 * @type {Number}
 		 */
 		port: null,
@@ -32,7 +32,7 @@ module.exports = {
 	avd: {
 		/**
 		 * The path to where AVDs are stored.
-		 * @type {Number}
+		 * @type {String}
 		 */
 		path: null
 	},
@@ -49,7 +49,7 @@ module.exports = {
 
 	env: {
 		/**
-		 * An override for the `PATH` environment variable.
+		 * An override for the `PATH` environment variable for androidlib's ADB detection.
 		 * @type {String}
 		 */
 		path: null
@@ -64,20 +64,6 @@ module.exports = {
 	},
 
 	genymotion: {
-		executables: {
-			/**
-			 * The path to the genymotion executable.
-			 * @type {String}
-			 */
-			genymotion: null,
-
-			/**
-			 * The path to the genymotion player executable.
-			 * @type {String}
-			 */
-			player: null
-		},
-
 		/**
 		 * A list of paths to search for Genymotion.
 		 * @type {Array.<String>}
@@ -107,15 +93,6 @@ module.exports = {
 		 * @type {String}
 		 */
 		configFile: null,
-
-		executables: {
-
-			/**
-			 * The path to the `vboxmanage` executable.
-			 * @type {String}
-			 */
-			vboxmanage: null,
-		},
 
 		/**
 		 * A list of paths to search for VirtualBox.

--- a/package.json
+++ b/package.json
@@ -22,12 +22,11 @@
     "source-map-support": "^0.5.13"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.2.0",
-    "gulp": "^4.0.2"
+    "appcd-gulp": "^2.2.0"
   },
-  "homepage": "https://github.com/appcelerator/appc-daemon-plugins/tree/master/packages/appcd-plugin-android",
-  "bugs": "https://github.com/appcelerator/appc-daemon-plugins/issues",
-  "repository": "https://github.com/appcelerator/appc-daemon-plugins",
+  "homepage": "https://github.com/appcelerator/appc-daemon",
+  "bugs": "https://github.com/appcelerator/appcd-plugin-android/issues",
+  "repository": "https://github.com/appcelerator/appcd-plugin-android",
   "appcd": {
     "appcdVersion": "3.x",
     "config": "./conf/config.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-android",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Android service for the Appc Daemon.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,7 +16,7 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "androidlib": "^2.5.0",
+    "androidlib": "^4.0.0",
     "gawk": "^4.6.4",
     "semver": "^6.3.0",
     "source-map-support": "^0.5.13"
@@ -29,7 +29,7 @@
   "bugs": "https://github.com/appcelerator/appc-daemon-plugins/issues",
   "repository": "https://github.com/appcelerator/appc-daemon-plugins",
   "appcd": {
-    "appcdVersion": "1.x || 2.x || 3.x",
+    "appcdVersion": "3.x",
     "config": "./conf/config.js",
     "name": "android",
     "type": "external"

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "androidlib": "^4.0.0",
-    "gawk": "^4.6.4",
+    "androidlib": "^4.0.1",
+    "gawk": "^4.6.6",
     "semver": "^6.3.0",
-    "source-map-support": "^0.5.13"
+    "source-map-support": "^0.5.16"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.2.0"
+    "appcd-gulp": "^2.3.0"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon",
   "bugs": "https://github.com/appcelerator/appcd-plugin-android/issues",


### PR DESCRIPTION
BREAKING CHANGE: Renamed 'sdk' and 'ndk' to 'sdks' and 'ndks'.
BREAKING CHANGE: No longer scan for deprecated 'android' executable.
BREAKING CHANGE: Removed 'targets'. Combine 'addons' and 'platforms' to get same result.
fix: Fixed bug with selecting the correct default Android SDK.
feat: Wired up live configuration changes. DAEMON-198
chore: Update dependencies.