### PR TITLE
v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.1.1 (Jun 23, 2020)
+
+ * refactor: Remove Genymotion detection where changes would simply triggered a rescan.
+   [(DAEMON-313)](https://jira.appcelerator.org/browse/DAEMON-313)
+ * build: Transpile using Node.js 10 profile.
+ * chore: Updated dependencies.
+
 # v2.0.3 (Jun 10, 2020)
 
  * fix: Gracefully handle adb connection issues.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,5 +4,5 @@ require('appcd-gulp')({
 	exports,
 	pkgJson:  require('./package.json'),
 	template: 'standard',
-	babel:    'node8'
+	babel:    'node10'
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-android",
-  "version": "2.0.3",
+  "version": "2.1.1",
   "description": "Android service for the Appc Daemon.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,13 +16,13 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "androidlib": "^4.1.0",
+    "androidlib": "^5.0.0",
     "gawk": "^4.7.1",
     "semver": "^7.3.2",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "appcd-gulp": "^3.0.0"
+    "appcd-gulp": "^3.0.1"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon",
   "bugs": "https://github.com/appcelerator/appcd-plugin-android/issues",

--- a/src/android-info-service.js
+++ b/src/android-info-service.js
@@ -224,22 +224,6 @@ export default class AndroidInfoService extends DataServiceDispatcher {
 			type: 'avd'
 		});
 
-		try {
-			const { response } = await appcd.call('/genymotion/1.x/info/emulators', { type: 'subscribe' });
-			response.on('data', rescan);
-		} catch (e) {
-			console.warn('Unable to subscribe to Genymotion, reverting to watching the VirtualBox config');
-			appcd.fs.watch({
-				debounce: true,
-				handler: rescan,
-				depth: 2,
-				paths: [
-					androidlib.virtualbox.virtualBoxConfigFile[process.platform]
-				],
-				type: 'vboxconf'
-			});
-		}
-
 		await new Promise((resolve, reject) => {
 			// if sdks change, then refresh the simulators and update the targets object
 			gawk.watch(this.data.sdks, async () => {


### PR DESCRIPTION
refactor: Remove Genymotion detection where changes would simply triggered a rescan. DAEMON-313
build: Transpile using Node.js 10 profile.
chore: Updated dependencies.